### PR TITLE
using mcs

### DIFF
--- a/cmd/link-processor/main.go
+++ b/cmd/link-processor/main.go
@@ -114,14 +114,14 @@ func main() {
 	failOnError(err, "Failed to connect to postgres")
 	defer func() {
 		err := linkStorage.Close()
-		fmt.Println("===== closed link storage =====", err)
+		log.Println("===== closed link storage =====", err)
 	}()
 
 	queue, err := linkqueue.NewLinkQueue(queueDataDir)
 	failOnError(err, "Failed to initialise queue")
 	defer func() {
 		err := queue.Close()
-		fmt.Println("===== closed link queue =====", err)
+		log.Println("===== closed link queue =====", err)
 	}()
 
 	pageBatcher, err := linkstorage.NewPageBatcher(
@@ -137,7 +137,7 @@ func main() {
 	}
 	defer func() {
 		err := pageBatcher.Close()
-		fmt.Println("===== closed page batcher =====", err)
+		log.Println("===== closed page batcher =====", err)
 	}()
 
 	linkBatcher, err := linkstorage.NewLinkBatcher(
@@ -153,7 +153,7 @@ func main() {
 	}
 	defer func() {
 		err := linkBatcher.Close()
-		fmt.Println("===== closed link batcher =====", err)
+		log.Println("===== closed link batcher =====", err)
 	}()
 
 	linkProcessor, err := linkprocessor.NewLinkProcessor(
@@ -166,7 +166,7 @@ func main() {
 	}
 	defer func() {
 		err := pageBatcher.Close()
-		fmt.Println("===== closed link processor =====", err)
+		log.Println("===== closed link processor =====", err)
 	}()
 
 	worker := func(u *url.URL) {

--- a/cmd/link-processor/main.go
+++ b/cmd/link-processor/main.go
@@ -209,12 +209,13 @@ func main() {
 	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP, syscall.SIGKILL)
 	ticker := time.NewTicker(10 * time.Minute)
 	defer ticker.Stop()
-	processing := true
-	for processing {
+
+running:
+	for {
 		select {
 		case s := <-sigs:
-			processing = false
 			log.Printf("Received signal %s, shutting down gracefully...\n", s)
+			break running
 		case url := <-queue.DeQueue():
 			linkProcessorPool.Put(context.TODO(), url)
 		case <-ticker.C:

--- a/cmd/link-processor/main.go
+++ b/cmd/link-processor/main.go
@@ -119,13 +119,6 @@ func main() {
 		log.Println("===== closed link storage =====", err)
 	}()
 
-	queue, err := linkqueue.NewLinkQueue(queueDataDir)
-	failOnError(err, "Failed to initialise queue")
-	defer func() {
-		err := queue.Close()
-		log.Println("===== closed link queue =====", err)
-	}()
-
 	pageBatcher, err := linkstorage.NewPageBatcher(
 		linkStorage,
 		pool.NewConfig(
@@ -160,6 +153,13 @@ func main() {
 		log.Println("===== closed link batcher =====", err)
 	}()
 
+	queue, err := linkqueue.NewLinkQueue(queueDataDir)
+	failOnError(err, "Failed to initialise queue")
+	defer func() {
+		err := queue.Close()
+		log.Println("===== closed link queue =====", err)
+	}()
+
 	linkProcessor, err := linkprocessor.NewLinkProcessor(
 		pageBatcher,
 		linkBatcher,
@@ -170,6 +170,9 @@ func main() {
 	}
 
 	worker := func(u *url.URL) {
+		if u == nil {
+			return
+		}
 		err := linkProcessor.ProcessURL(u)
 		if err != nil {
 			log.Printf("Error whilst processing: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/jamesjarvis/web-graph
 
-go 1.15
+go 1.18
 
 require (
 	github.com/PuerkitoBio/goquery v1.5.1
-	github.com/andybalholm/cascadia v1.2.0 // indirect
 	github.com/beeker1121/goque v2.1.0+incompatible
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.6.3
@@ -12,6 +11,24 @@ require (
 	github.com/lib/pq v1.9.0
 	github.com/ncruces/go-dns v1.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+)
+
+require (
+	github.com/andybalholm/cascadia v1.2.0 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-playground/validator/v10 v10.2.0 // indirect
+	github.com/golang/protobuf v1.3.3 // indirect
+	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
+	github.com/json-iterator/go v1.1.9 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
+	github.com/ugorji/go/codec v1.1.7 // indirect
 	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.6.3
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/jamesjarvis/massivelyconcurrentsystems v0.0.0-20220704201925-a6bb05700ec6
 	github.com/lib/pq v1.9.0
 	github.com/ncruces/go-dns v1.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/jamesjarvis/massivelyconcurrentsystems v0.0.0-20220704201925-a6bb05700ec6 h1:k9pD775XqAAQvbOG5UkFzdE755c/cEFT4ToS66OnKPE=
+github.com/jamesjarvis/massivelyconcurrentsystems v0.0.0-20220704201925-a6bb05700ec6/go.mod h1:iP6trICGTPXrFrb6QspFH6hOXZV2hzyncb6NWk+NFxw=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -77,6 +79,7 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
+go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
-github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andybalholm/cascadia v1.2.0 h1:vuRCkM5Ozh/BfmsaTm26kbjm0mIOM3yS5Ek/F5h18aE=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
@@ -9,7 +8,6 @@ github.com/beeker1121/goque v2.1.0+incompatible/go.mod h1:L6dOWBhDOnxUVQsb0wkLve
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gin-contrib/cors v1.3.1 h1:doAsuITavI4IOcd0Y19U4B+O0dNWihRyX//nn4sEmgA=
 github.com/gin-contrib/cors v1.3.1/go.mod h1:jjEJ4268OPZUcU7k9Pm653S7lXUGcqMADzFA61xsmDk=
@@ -28,7 +26,6 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
@@ -77,7 +74,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
-github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
@@ -86,11 +82,9 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc h1:zK/HqS5bZxDptfPJNq8v7vJfXtkU7r9TLIoSr1bXaP4=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -99,12 +93,10 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -114,7 +106,6 @@ gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8
 gopkg.in/go-playground/validator.v9 v9.29.1/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=

--- a/pkg/linkstorage/batchlink.go
+++ b/pkg/linkstorage/batchlink.go
@@ -25,7 +25,7 @@ func NewLinkBatcher(s *Storage, config pool.Config) (*pool.WorkDispatcher[pool.U
 
 		err := s.ResilientBatchAddLinks(links)
 		if err != nil {
-			log.Printf("Batch adding links failed!: %e", err)
+			log.Printf("Batch adding links failed!: %v", err)
 			return err
 		}
 

--- a/pkg/linkstorage/batchlink.go
+++ b/pkg/linkstorage/batchlink.go
@@ -3,13 +3,9 @@ package linkstorage
 import (
 	"log"
 	"net/url"
-	"time"
 
-	"github.com/lib/pq"
+	"github.com/jamesjarvis/massivelyconcurrentsystems/pool"
 )
-
-//TODO: Write a batch consumer, that consumes links from a channel in batches of max 100 and writes to the database
-// https://blog.drkaka.com/batch-get-from-golangs-buffered-channel-9638573f0c6e
 
 // Link is a link object
 type Link struct {
@@ -18,142 +14,27 @@ type Link struct {
 	LinkText string
 }
 
-// LinkBatcher is a simple batching system for recording links to the db
-type LinkBatcher struct {
-	maxBatch     int
-	bufChan      chan *Link
-	s            *Storage
-	killChannels []chan bool
-	doneChannels []chan bool
-}
-
 // NewLinkBatcher is a helpfer function for constructing a LinkBatcher object
-func NewLinkBatcher(maxBatch int, s *Storage) *LinkBatcher {
-	return &LinkBatcher{
-		maxBatch: maxBatch,
-		bufChan:  make(chan *Link, maxBatch*8),
-		s:        s,
-	}
-}
-
-// Worker is the worker process for the link batcher
-// This is straight up nicked from https://blog.drkaka.com/batch-get-from-golangs-buffered-channel-9638573f0c6e
-func (lb *LinkBatcher) Worker(endSignal <-chan bool, doneChan chan<- bool) {
-	// We want it to die on the endSignal, but otherwise keep looping
-	for {
-		select {
-		case <-endSignal:
-			doneChan <- true
-			return
-		case <-time.After(10 * time.Millisecond):
-			var links []*Link
-
-		Remaining:
-			for i := 0; i < lb.maxBatch; i++ {
-				select {
-				case link := <-lb.bufChan:
-					links = append(links, link)
-				default:
-					break Remaining
-				}
-			}
-
-			if len(links) == 0 {
-				break
-			}
-
-			// Ok I know this is a bit dirty, but basically sometimes we get foreign key issues
-			// So I'm just going to keep retrying it until eventually the page is added right?
-
-			err := lb.ResilientBatchAddLinks(links)
-			if err != nil {
-				log.Printf("Batch adding links failed!: %e", err)
-			}
+func NewLinkBatcher(s *Storage, config pool.Config) (*pool.WorkDispatcher[pool.UnitOfWork[*Link, bool]], error) {
+	batchWorker := func(us []pool.UnitOfWork[*Link, bool]) error {
+		// The batch processing
+		links := make([]*Link, 0, len(us))
+		for _, p := range us {
+			links = append(links, p.GetRequest())
 		}
-	}
-}
 
-// WaitUntilEmpty returns a channel that receives input once the buffered channel is empty.
-func (lb *LinkBatcher) WaitUntilEmpty() <-chan bool {
-	emptyChan := make(chan bool)
-	go func() {
-		for {
-			if len(lb.bufChan) == 0 {
-				emptyChan <- true
-			}
-		}
-	}()
-	return emptyChan
-}
-
-// ResilientBatchAddLinks shrinks the batch sizes until it eventually works :shrug:
-func (lb *LinkBatcher) ResilientBatchAddLinks(links []*Link) error {
-	maxRetries := 20
-	var retryCount int
-	var err error
-	batchSize := len(links)
-	tempBatch := links
-	// This simply backs off retries with this shitty foreign key error.
-	for batchSize >= 1 {
-		err = lb.s.BatchAddLinks(tempBatch[:batchSize])
+		err := s.ResilientBatchAddLinks(links)
 		if err != nil {
-			// If we know this kind of error, we backoff for a bit and retry the same batch.
-			if pqErr, ok := err.(*pq.Error); ok {
-				// Here err is of type *pq.Error, you may inspect all its fields, e.g.:
-				if pqErr.Code == "23503" {
-					retryCount++
-					// Here the error code is a foreign_key_violation, and we can maaaybe assume that the link will eventually be added so we retry this for 10 seconds or so.
-					if retryCount > 10 {
-						log.Printf("retrying foreign_key_violation %d/%d\n", retryCount+1, maxRetries)
-					}
-					if retryCount == maxRetries {
-						log.Printf("Gave up after %d retries!\n", retryCount)
-						break
-					}
-					time.Sleep(time.Duration(retryCount) * 50 * time.Millisecond)
-					continue
-				}
-			}
-			// Here we do not know the kind of error, but know there is one.
-			if batchSize > 1 {
-				log.Printf("Encountered weird error with batch size %d, splitting the batch...", batchSize)
-				batchSize = batchSize / 2
-				// time.Sleep(50 * time.Millisecond)
-				continue
-			}
-			log.Printf("Skipping failed message %d\n", len(links)-len(tempBatch))
+			log.Printf("Batch adding links failed!: %e", err)
+			return err
 		}
-		// Here the batch size == 1, and there is an error we do not know, so we decide to skip that message.
-		// Or if there was no error, we continue through the batch.
-		tempBatch = tempBatch[batchSize:]
-		batchSize = len(tempBatch)
-	}
-	return err
-}
 
-// SpawnWorkers spawns n workers, and returns a kill channel
-func (lb *LinkBatcher) SpawnWorkers(nWorkers int) {
-	for i := 0; i < nWorkers; i++ {
-		killChan := make(chan bool)
-		doneChan := make(chan bool)
-		lb.killChannels = append(lb.killChannels, killChan)
-		lb.doneChannels = append(lb.doneChannels, doneChan)
-		go lb.Worker(killChan, doneChan)
+		return nil
 	}
-}
 
-// KillWorkers simply kills all previously spawned workers
-func (lb *LinkBatcher) KillWorkers() {
-	for _, workerKillChan := range lb.killChannels {
-		workerKillChan <- true
-	}
-	for _, doneChan := range lb.doneChannels {
-		<-doneChan
-	}
-}
-
-// AddLink is a lightweight function to just whack that link into the channel
-func (lb *LinkBatcher) AddLink(link *Link) error {
-	lb.bufChan <- link
-	return nil
+	batchDispatcher := pool.NewBatchDispatcher(
+		batchWorker,
+		config,
+	)
+	return batchDispatcher, nil
 }

--- a/pkg/linkstorage/batchpage.go
+++ b/pkg/linkstorage/batchpage.go
@@ -36,7 +36,7 @@ func NewPageBatcher(s *Storage, config pool.Config) (*pool.WorkDispatcher[pool.U
 
 		err := s.BatchAddPages(pages)
 		if err != nil {
-			log.Printf("Batch adding pages failed!: %e", err)
+			log.Printf("Batch adding pages failed!: %v", err)
 			return err
 		}
 

--- a/pkg/linkstorage/batchpage.go
+++ b/pkg/linkstorage/batchpage.go
@@ -14,18 +14,8 @@ type Page struct {
 	U *url.URL
 }
 
-// PageBatcher is a simple batching system for recording links to the db
-type PageBatcher struct {
-	maxBatch     int
-	bufChan      chan *Page
-	s            *Storage
-	killChannels []chan bool
-	doneChannels []chan bool
-	Cache        *lru.Cache
-}
-
 // NewPageBatcher is a helpfer function for constructing a PageBatcher object
-func NewPageBatcher(maxBatch, numConsumers int, s *Storage) (*pool.WorkDispatcher[pool.UnitOfWork[Page, bool]], error) {
+func NewPageBatcher(s *Storage, config pool.Config) (*pool.WorkDispatcher[pool.UnitOfWork[Page, bool]], error) {
 	cache, err := lru.New(100000)
 	if err != nil {
 		return nil, err
@@ -55,93 +45,7 @@ func NewPageBatcher(maxBatch, numConsumers int, s *Storage) (*pool.WorkDispatche
 
 	batchDispatcher := pool.NewBatchDispatcher(
 		batchWorker,
-		pool.NewConfig(
-			pool.SetBatchSize(maxBatch),
-			pool.SetBufferSize(maxBatch*8),
-			pool.SetNumConsumers(numConsumers),
-		),
+		config,
 	)
 	return batchDispatcher, nil
 }
-
-// // WaitUntilEmpty returns a channel that receives input once the buffered channel is empty.
-// func (pb *PageBatcher) WaitUntilEmpty() <-chan bool {
-// 	emptyChan := make(chan bool)
-// 	go func() {
-// 		for {
-// 			if len(pb.bufChan) == 0 {
-// 				emptyChan <- true
-// 			}
-// 		}
-// 	}()
-// 	return emptyChan
-// }
-
-// // Worker is the worker process for the page batcher
-// // This is straight up nicked from https://blog.drkaka.com/batch-get-from-golangs-buffered-channel-9638573f0c6e
-// func (pb *PageBatcher) Worker(endSignal <-chan bool, doneChan chan<- bool) {
-// 	// We want it to die on the endSignal, but otherwise keep looping
-// 	for {
-// 		select {
-// 		case <-endSignal:
-// 			doneChan <- true
-// 			return
-// 		case <-time.After(10 * time.Millisecond):
-// 			var pages []*Page
-
-// 		Remaining:
-// 			for i := 0; i < pb.maxBatch; i++ {
-// 				select {
-// 				case page := <-pb.bufChan:
-// 					pages = append(pages, page)
-// 				default:
-// 					break Remaining
-// 				}
-// 			}
-
-// 			if len(pages) == 0 {
-// 				break
-// 			}
-
-// 			// The batch processing
-// 			// log.Printf("Batch adding pages of size %d", len(pages))
-// 			err := pb.s.BatchAddPages(pages)
-// 			if err != nil {
-// 				log.Printf("Batch adding pages failed!: %e", err)
-// 			}
-
-// 		}
-// 	}
-// }
-
-// // SpawnWorkers spawns n workers, and returns a kill channel
-// func (pb *PageBatcher) SpawnWorkers(nWorkers int) {
-// 	for i := 0; i < nWorkers; i++ {
-// 		killChan := make(chan bool)
-// 		doneChan := make(chan bool)
-// 		pb.killChannels = append(pb.killChannels, killChan)
-// 		pb.doneChannels = append(pb.doneChannels, doneChan)
-// 		go pb.Worker(killChan, doneChan)
-// 	}
-// }
-
-// // KillWorkers simply kills all previously spawned workers
-// func (pb *PageBatcher) KillWorkers() {
-// 	for _, workerKillChan := range pb.killChannels {
-// 		workerKillChan <- true
-// 	}
-// 	for _, doneChan := range pb.doneChannels {
-// 		<-doneChan
-// 	}
-// }
-
-// // AddPage is a lightweight function to just whack that page into the channel
-// // Returns true if it added the page (hadn't been added previously)
-// func (pb *PageBatcher) AddPage(page *Page) bool {
-// 	ok, _ := pb.Cache.ContainsOrAdd(linkutils.Hash(page.U), struct{}{})
-// 	if !ok {
-// 		pb.bufChan <- page
-// 		return true
-// 	}
-// 	return false
-// }

--- a/pkg/linkstorage/batchpage.go
+++ b/pkg/linkstorage/batchpage.go
@@ -3,14 +3,11 @@ package linkstorage
 import (
 	"log"
 	"net/url"
-	"time"
 
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/jamesjarvis/massivelyconcurrentsystems/pool"
 	"github.com/jamesjarvis/web-graph/pkg/linkutils"
 )
-
-//TODO: Write a batch consumer, that consumes pages from a channel in batches of max 100 and writes to the database
-// https://blog.drkaka.com/batch-get-from-golangs-buffered-channel-9638573f0c6e
 
 // Page is a page object
 type Page struct {
@@ -28,97 +25,123 @@ type PageBatcher struct {
 }
 
 // NewPageBatcher is a helpfer function for constructing a PageBatcher object
-func NewPageBatcher(maxBatch int, s *Storage) (*PageBatcher, error) {
+func NewPageBatcher(maxBatch, numConsumers int, s *Storage) (*pool.WorkDispatcher[pool.UnitOfWork[Page, bool]], error) {
 	cache, err := lru.New(100000)
 	if err != nil {
 		return nil, err
 	}
-	return &PageBatcher{
-		maxBatch: maxBatch,
-		bufChan:  make(chan *Page, maxBatch*4),
-		s:        s,
-		Cache:    cache,
-	}, nil
-}
 
-// WaitUntilEmpty returns a channel that receives input once the buffered channel is empty.
-func (pb *PageBatcher) WaitUntilEmpty() <-chan bool {
-	emptyChan := make(chan bool)
-	go func() {
-		for {
-			if len(pb.bufChan) == 0 {
-				emptyChan <- true
+	batchWorker := func(us []pool.UnitOfWork[Page, bool]) error {
+		// The batch processing
+		// log.Printf("Batch adding pages of size %d", len(pages))
+
+		pages := make([]Page, 0, len(us))
+		for _, p := range us {
+			ok, _ := cache.ContainsOrAdd(linkutils.Hash(p.GetRequest().U), struct{}{})
+			if ok {
+				continue
 			}
+			pages = append(pages, p.GetRequest())
 		}
-	}()
-	return emptyChan
-}
 
-// Worker is the worker process for the page batcher
-// This is straight up nicked from https://blog.drkaka.com/batch-get-from-golangs-buffered-channel-9638573f0c6e
-func (pb *PageBatcher) Worker(endSignal <-chan bool, doneChan chan<- bool) {
-	// We want it to die on the endSignal, but otherwise keep looping
-	for {
-		select {
-		case <-endSignal:
-			doneChan <- true
-			return
-		case <-time.After(10 * time.Millisecond):
-			var pages []*Page
-
-		Remaining:
-			for i := 0; i < pb.maxBatch; i++ {
-				select {
-				case page := <-pb.bufChan:
-					pages = append(pages, page)
-				default:
-					break Remaining
-				}
-			}
-
-			if len(pages) == 0 {
-				break
-			}
-
-			// The batch processing
-			// log.Printf("Batch adding pages of size %d", len(pages))
-			err := pb.s.BatchAddPages(pages)
-			if err != nil {
-				log.Printf("Batch adding pages failed!: %e", err)
-			}
-
+		err := s.BatchAddPages(pages)
+		if err != nil {
+			log.Printf("Batch adding pages failed!: %e", err)
+			return err
 		}
+
+		return nil
 	}
+
+	batchDispatcher := pool.NewBatchDispatcher(
+		batchWorker,
+		pool.NewConfig(
+			pool.SetBatchSize(maxBatch),
+			pool.SetBufferSize(maxBatch*8),
+			pool.SetNumConsumers(numConsumers),
+		),
+	)
+	return batchDispatcher, nil
 }
 
-// SpawnWorkers spawns n workers, and returns a kill channel
-func (pb *PageBatcher) SpawnWorkers(nWorkers int) {
-	for i := 0; i < nWorkers; i++ {
-		killChan := make(chan bool)
-		doneChan := make(chan bool)
-		pb.killChannels = append(pb.killChannels, killChan)
-		pb.doneChannels = append(pb.doneChannels, doneChan)
-		go pb.Worker(killChan, doneChan)
-	}
-}
+// // WaitUntilEmpty returns a channel that receives input once the buffered channel is empty.
+// func (pb *PageBatcher) WaitUntilEmpty() <-chan bool {
+// 	emptyChan := make(chan bool)
+// 	go func() {
+// 		for {
+// 			if len(pb.bufChan) == 0 {
+// 				emptyChan <- true
+// 			}
+// 		}
+// 	}()
+// 	return emptyChan
+// }
 
-// KillWorkers simply kills all previously spawned workers
-func (pb *PageBatcher) KillWorkers() {
-	for _, workerKillChan := range pb.killChannels {
-		workerKillChan <- true
-	}
-	for _, doneChan := range pb.doneChannels {
-		<-doneChan
-	}
-}
+// // Worker is the worker process for the page batcher
+// // This is straight up nicked from https://blog.drkaka.com/batch-get-from-golangs-buffered-channel-9638573f0c6e
+// func (pb *PageBatcher) Worker(endSignal <-chan bool, doneChan chan<- bool) {
+// 	// We want it to die on the endSignal, but otherwise keep looping
+// 	for {
+// 		select {
+// 		case <-endSignal:
+// 			doneChan <- true
+// 			return
+// 		case <-time.After(10 * time.Millisecond):
+// 			var pages []*Page
 
-// AddPage is a lightweight function to just whack that page into the channel
-// Returns true if it added the page (hadn't been added previously)
-func (pb *PageBatcher) AddPage(page *Page) bool {
-	ok, _ := pb.Cache.ContainsOrAdd(linkutils.Hash(page.U), struct{}{})
-	if !ok {
-		pb.bufChan <- page
-		return true
-	}
-	return false
-}
+// 		Remaining:
+// 			for i := 0; i < pb.maxBatch; i++ {
+// 				select {
+// 				case page := <-pb.bufChan:
+// 					pages = append(pages, page)
+// 				default:
+// 					break Remaining
+// 				}
+// 			}
+
+// 			if len(pages) == 0 {
+// 				break
+// 			}
+
+// 			// The batch processing
+// 			// log.Printf("Batch adding pages of size %d", len(pages))
+// 			err := pb.s.BatchAddPages(pages)
+// 			if err != nil {
+// 				log.Printf("Batch adding pages failed!: %e", err)
+// 			}
+
+// 		}
+// 	}
+// }
+
+// // SpawnWorkers spawns n workers, and returns a kill channel
+// func (pb *PageBatcher) SpawnWorkers(nWorkers int) {
+// 	for i := 0; i < nWorkers; i++ {
+// 		killChan := make(chan bool)
+// 		doneChan := make(chan bool)
+// 		pb.killChannels = append(pb.killChannels, killChan)
+// 		pb.doneChannels = append(pb.doneChannels, doneChan)
+// 		go pb.Worker(killChan, doneChan)
+// 	}
+// }
+
+// // KillWorkers simply kills all previously spawned workers
+// func (pb *PageBatcher) KillWorkers() {
+// 	for _, workerKillChan := range pb.killChannels {
+// 		workerKillChan <- true
+// 	}
+// 	for _, doneChan := range pb.doneChannels {
+// 		<-doneChan
+// 	}
+// }
+
+// // AddPage is a lightweight function to just whack that page into the channel
+// // Returns true if it added the page (hadn't been added previously)
+// func (pb *PageBatcher) AddPage(page *Page) bool {
+// 	ok, _ := pb.Cache.ContainsOrAdd(linkutils.Hash(page.U), struct{}{})
+// 	if !ok {
+// 		pb.bufChan <- page
+// 		return true
+// 	}
+// 	return false
+// }

--- a/pkg/linkstorage/linkstorage.go
+++ b/pkg/linkstorage/linkstorage.go
@@ -396,6 +396,10 @@ func (s *Storage) BatchAddLinks(links []*Link) error {
 	// s.AddPage(fromU)
 	// s.AddPage(toU)
 
+	if len(links) == 0 {
+		return nil
+	}
+
 	valueStrings := make([]string, 0, len(links))
 	vals := []interface{}{}
 
@@ -473,6 +477,10 @@ func (s *Storage) ResilientBatchAddLinks(links []*Link) error {
 
 // BatchAddPages takes a batch of pages and inserts them, not giving a fuck whether or not they clash
 func (s *Storage) BatchAddPages(pages []Page) error {
+	if len(pages) == 0 {
+		return nil
+	}
+
 	valueStrings := make([]string, 0, len(pages))
 	vals := []interface{}{}
 

--- a/pkg/linkstorage/linkstorage.go
+++ b/pkg/linkstorage/linkstorage.go
@@ -493,6 +493,7 @@ func (s *Storage) BatchAddPages(pages []Page) error {
 	//prepare the statement
 	stmt, err := s.db.Prepare(sqlStr)
 	if err != nil {
+		// TODO(jamesjarvis): bug here, think it is the way we create the query.
 		return err
 	}
 	defer stmt.Close()

--- a/pkg/linkstorage/linkstorage.go
+++ b/pkg/linkstorage/linkstorage.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jamesjarvis/web-graph/pkg/linkutils"
+	"github.com/lib/pq"
 )
 
 // Storage implements a PostgreSQL storage backend for colly
@@ -422,6 +423,51 @@ func (s *Storage) BatchAddLinks(links []*Link) error {
 	//format all vals at once
 	_, err = stmt.Exec(vals...)
 
+	return err
+}
+
+// ResilientBatchAddLinks shrinks the batch sizes until it eventually works :shrug:
+func (s *Storage) ResilientBatchAddLinks(links []*Link) error {
+	maxRetries := 20
+	var retryCount int
+	var err error
+	batchSize := len(links)
+	tempBatch := links
+	// This simply backs off retries with this shitty foreign key error.
+	for batchSize >= 1 {
+		err = s.BatchAddLinks(tempBatch[:batchSize])
+		if err != nil {
+			// If we know this kind of error, we backoff for a bit and retry the same batch.
+			if pqErr, ok := err.(*pq.Error); ok {
+				// Here err is of type *pq.Error, you may inspect all its fields, e.g.:
+				if pqErr.Code == "23503" {
+					retryCount++
+					// Here the error code is a foreign_key_violation, and we can maaaybe assume that the link will eventually be added so we retry this for 10 seconds or so.
+					if retryCount > 10 {
+						log.Printf("retrying foreign_key_violation %d/%d\n", retryCount+1, maxRetries)
+					}
+					if retryCount == maxRetries {
+						log.Printf("Gave up after %d retries!\n", retryCount)
+						break
+					}
+					time.Sleep(time.Duration(retryCount) * 50 * time.Millisecond)
+					continue
+				}
+			}
+			// Here we do not know the kind of error, but know there is one.
+			if batchSize > 1 {
+				log.Printf("Encountered weird error with batch size %d, splitting the batch...", batchSize)
+				batchSize = batchSize / 2
+				// time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			log.Printf("Skipping failed message %d\n", len(links)-len(tempBatch))
+		}
+		// Here the batch size == 1, and there is an error we do not know, so we decide to skip that message.
+		// Or if there was no error, we continue through the batch.
+		tempBatch = tempBatch[batchSize:]
+		batchSize = len(tempBatch)
+	}
 	return err
 }
 

--- a/pkg/linkstorage/linkstorage.go
+++ b/pkg/linkstorage/linkstorage.go
@@ -426,7 +426,7 @@ func (s *Storage) BatchAddLinks(links []*Link) error {
 }
 
 // BatchAddPages takes a batch of pages and inserts them, not giving a fuck whether or not they clash
-func (s *Storage) BatchAddPages(pages []*Page) error {
+func (s *Storage) BatchAddPages(pages []Page) error {
 	valueStrings := make([]string, 0, len(pages))
 	vals := []interface{}{}
 

--- a/up.sh
+++ b/up.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-docker-compose up --build -d
-docker-compose push
+# docker-compose up --build -d
+# docker-compose push
 
 # sleep 10s
 


### PR DESCRIPTION
- upgrade to go 1.18
- remove unused lines
- use batchworker for page batcher
- page batcher is just a worker now
- link processor uses page batcher
- main uses defers instead of custom graceful shutdown logic
- change link batcher to use mcs batch worker
- change error log to %v
- add todo
- replace fmt with log
- add handler for empty input case
- accidentally closed pageBatcher twice
- smol bugs here and there
- remove weird boolean
